### PR TITLE
Fix wrong parameter when creating issue

### DIFF
--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -246,7 +246,10 @@ async def confirm_issue_creation(update: Update, context: CallbackContext):
         f"🔗 @{user.username or 'без username'}"
     )
 
-    issue = await tracker.create_issue(title, full_description, attachments, telegram_id=user.id)
+    extra_fields = {"telegramId": str(user.id)}
+    if attachments:
+        extra_fields["attachments"] = attachments
+    issue = await tracker.create_issue(title, full_description, extra_fields)
     if issue and "key" in issue:
         await db.create_issue(user.id, issue["key"])
         await query.message.reply_text(

--- a/tracker_client.py
+++ b/tracker_client.py
@@ -77,9 +77,11 @@ class TrackerAPI:
                 raise Exception(f"Search issues failed: {resp.status} {text}")
             return await resp.json()
 
-    async def add_comment(self, issue_key, comment):
+    async def add_comment(self, issue_key, comment, attachments=None):
         url = f"{self.base_url}/v2/issues/{issue_key}/comments"
         data = {"text": comment}
+        if attachments:
+            data["attachments"] = attachments
         session = await self.get_session()
         headers = self._get_headers()
         async with session.post(url, json=data, headers=headers) as resp:


### PR DESCRIPTION
## Summary
- create issue with `telegramId` and attachments in a single dictionary
- allow `add_comment` to send attachments

## Testing
- `python -m py_compile handlers_issue.py tracker_client.py`

------
https://chatgpt.com/codex/tasks/task_e_68470b752744832b9b531706fc92457d