### PR TITLE
Fix tracker header and import missing context

### DIFF
--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -5,7 +5,7 @@ import logging
 import os
 from collections import defaultdict
 from typing import Final, List, Dict
-from telegram.ext import ContextTypes
+from telegram.ext import ContextTypes, CallbackContext
 
 from telegram import (
     Update,

--- a/tracker_client.py
+++ b/tracker_client.py
@@ -27,7 +27,10 @@ class TrackerAPI:
             "Content-Type": "application/json",
         }
         if self.org_id:
-            headers["X-Org-Id"] = self.org_id
+            # Yandex Tracker expects the organization ID in the ``X-Org-ID``
+            # header. Previously ``X-Org-Id`` was used which caused a 403
+            # "Organization is not available" error when creating issues.
+            headers["X-Org-ID"] = self.org_id
         return headers
 
     async def create_issue(self, title, description, extra_fields=None):


### PR DESCRIPTION
## Summary
- fix header name used for Tracker API organization id
- import `CallbackContext` in issue handlers

## Testing
- `python -m py_compile tracker_client.py handlers_issue.py handlers_common.py config.py n8n_client.py database.py states.py webhook_server.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68470e084550832b9259697e2d150af7