### PR TITLE
Use X-Cloud-Org-ID header

### DIFF
--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -5,7 +5,7 @@ import logging
 import os
 from collections import defaultdict
 from typing import Final, List, Dict
-from telegram.ext import ContextTypes
+from telegram.ext import ContextTypes, CallbackContext
 
 from telegram import (
     Update,

--- a/tracker_client.py
+++ b/tracker_client.py
@@ -27,7 +27,12 @@ class TrackerAPI:
             "Content-Type": "application/json",
         }
         if self.org_id:
-            headers["X-Org-Id"] = self.org_id
+            # Yandex Tracker Cloud uses the ``X-Cloud-Org-ID`` header. Some
+            # on-prem deployments still rely on ``X-Org-ID``, so include both
+            # to remain compatible while avoiding 403 errors about a missing
+            # organization.
+            headers["X-Cloud-Org-ID"] = self.org_id
+            headers["X-Org-ID"] = self.org_id
         return headers
 
     async def create_issue(self, title, description, extra_fields=None):


### PR DESCRIPTION
## Summary
- send the organization as `X-Cloud-Org-ID` for Tracker Cloud
- keep `X-Org-ID` for older deployments

## Testing
- `python -m py_compile tracker_client.py handlers_issue.py handlers_common.py config.py n8n_client.py database.py states.py webhook_server.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68470e084550832b9259697e2d150af7