### PR TITLE
Fix attachment field and main menu buttons

### DIFF
--- a/handlers_common.py
+++ b/handlers_common.py
@@ -14,24 +14,23 @@ from states import RegistrationStates
 from database import Database
 from keyboards import (
     main_reply_keyboard,
-    main_inline_keyboard,
     contact_keyboard,
 )
 from states import RegistrationStates
 
 
-# Универсальная функция для вывода только inline-меню
-async def show_main_inline_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
+# Универсальная функция для вывода главного меню с reply-кнопками
+async def show_main_reply_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if update.callback_query:
         await update.callback_query.answer()
-        await update.callback_query.edit_message_text(
+        await update.callback_query.message.reply_text(
             "Главное меню:",
-            reply_markup=main_inline_keyboard()
+            reply_markup=main_reply_keyboard()
         )
     elif update.message:
         await update.message.reply_text(
             "Главное меню:",
-            reply_markup=main_inline_keyboard()
+            reply_markup=main_reply_keyboard()
         )
 
 # ────────────────────────── /start  ─────────────────────────────
@@ -40,11 +39,11 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     db = context.bot_data["db"]
     user_info = await db.get_user(user_id)
     if user_info:
-        await show_main_inline_menu(update, context)
+        await show_main_reply_menu(update, context)
         return ConversationHandler.END
     # ... логика регистрации ...
     # После успешной регистрации тоже вызвать:
-    # await show_main_inline_menu(update, context)
+    # await show_main_reply_menu(update, context)
 
 async def show_user_info(update, context):
     db = context.bot_data["db"]
@@ -79,26 +78,25 @@ async def process_contact(update: Update, context: CallbackContext):
         contact.phone_number,
     )
 
-    # После регистрации показываем оба меню.
+    # После регистрации показываем главное меню.
     await main_menu(update, context)
     return ConversationHandler.END
 
 
 # ──────────────────────── главное меню (универсальное) ────────────────────
 async def main_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """
-    Главный вход во все ситуации: всегда только inline-меню, без reply
-    """
+    """Отображает главное меню с reply-кнопками."""
     if update.callback_query:
         await update.callback_query.answer()
-        await update.callback_query.edit_message_text(
+        await update.callback_query.edit_message_reply_markup(reply_markup=None)
+        await update.callback_query.message.reply_text(
             "Главное меню:",
-            reply_markup=main_inline_keyboard()
+            reply_markup=main_reply_keyboard()
         )
     elif update.message:
         await update.message.reply_text(
             "Главное меню:",
-            reply_markup=main_inline_keyboard()
+            reply_markup=main_reply_keyboard()
         )
 
 def register_handlers(application):

--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -28,7 +28,6 @@ from tracker_client import TrackerAPI
 from states import IssueStates
 from keyboards import (
     main_reply_keyboard,
-    main_inline_keyboard,
 )
 
 # ──────────────────────────── буфер медиа‑альбомов ─────────────────────────────
@@ -248,7 +247,8 @@ async def confirm_issue_creation(update: Update, context: CallbackContext):
 
     extra_fields = {"telegramId": str(user.id)}
     if attachments:
-        extra_fields["attachments"] = attachments
+        # При создании задачи вложения передаются через поле attachmentIds
+        extra_fields["attachmentIds"] = attachments
     issue = await tracker.create_issue(title, full_description, extra_fields)
     if issue and "key" in issue:
         await db.create_issue(user.id, issue["key"])


### PR DESCRIPTION
## Summary
- show reply keyboard for main menu instead of inline buttons
- send attachments as `attachmentIds` when creating issues

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6847c3971a98832bb5a1475b1a53c520