### PR TITLE
Fix comment API and improve UX

### DIFF
--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -273,7 +273,12 @@ async def select_issue_for_comment(update: Update, context: CallbackContext):
     query = update.callback_query
     issue_key = query.data.split("_", 1)[1]
     context.user_data["issue_key"] = issue_key
-    await query.message.reply_text("📝 Напишите комментарий или прикрепите файл…")
+    await query.message.reply_text(
+        "📝 Напишите комментарий или прикрепите файл…",
+        reply_markup=InlineKeyboardMarkup(
+            [[InlineKeyboardButton("🔄 Главное меню", callback_data="main_menu")]]
+        ),
+    )
     return IssueStates.waiting_for_comment
 
 async def process_comment(update: Update, context: CallbackContext):
@@ -284,7 +289,7 @@ async def process_comment(update: Update, context: CallbackContext):
         await safe_reply_text(update.message, "❌ Сначала выберите задачу в списке.")
         return ConversationHandler.END
 
-    text = update.message.text.strip() if update.message.text else "📎 Вложение"
+    text = (update.message.text or update.message.caption or "📎 Вложение").strip()
     attachment_ids: list[int] = []
 
     # Если в сообщении есть файл — загружаем

--- a/tracker_client.py
+++ b/tracker_client.py
@@ -86,11 +86,42 @@ class TrackerAPI:
         ]
         return filtered
 
-    async def add_comment(self, issue_key, comment, attachments=None):
+    async def add_comment(
+        self,
+        issue_key,
+        comment,
+        attachment_ids=None,
+        summonees=None,
+        maillist_summonees=None,
+        markup_type="md",
+    ):
+        """Add a comment to an issue using the modern API.
+
+        Parameters
+        ----------
+        issue_key : str
+            Key of the issue.
+        comment : str
+            Comment text.
+        attachment_ids : list[str] | None
+            Temporary file identifiers for attachments.
+        summonees : list[str] | None
+            Users to mention in the comment.
+        maillist_summonees : list[str] | None
+            Mailing lists to mention.
+        markup_type : str
+            Markup type of ``comment``. ``md`` enables Markdown/YFM.
+        """
+
         url = f"{self.base_url}/v2/issues/{issue_key}/comments"
-        data = {"text": comment}
-        if attachments:
-            data["attachments"] = attachments
+        data = {"text": comment, "markupType": markup_type}
+        if attachment_ids:
+            data["attachmentIds"] = attachment_ids
+        if summonees:
+            data["summonees"] = summonees
+        if maillist_summonees:
+            data["maillistSummonees"] = maillist_summonees
+
         session = await self.get_session()
         headers = self._get_headers()
         async with session.post(url, json=data, headers=headers) as resp:


### PR DESCRIPTION
## Summary
- use `attachmentIds` for Tracker comment API and support optional arguments
- show inline button when asking for a comment
- handle text from message captions

## Testing
- `python -m py_compile handlers_issue.py tracker_client.py`
- `python -m unittest discover`
- `pip install flake8`
- `flake8 handlers_issue.py tracker_client.py` *(fails: command not found initially)*

------
https://chatgpt.com/codex/tasks/task_e_6847f90dc53c832ba7f790927c35b29e