### PR TITLE
Implement tracker helper methods and tests

### DIFF
--- a/tests/test_tracker_client.py
+++ b/tests/test_tracker_client.py
@@ -1,0 +1,74 @@
+from unittest.mock import AsyncMock, MagicMock
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+class MockResponse:
+    def __init__(self, json_data, status=200):
+        self._json = json_data
+        self.status = status
+
+    async def json(self):
+        return self._json
+
+    async def text(self):
+        return str(self._json)
+
+    async def read(self):
+        return b""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+import pytest
+
+from tracker_client import TrackerAPI
+
+@pytest.mark.asyncio
+async def test_get_headers():
+    api = TrackerAPI('http://example.com', 'TOKEN', org_id='ORG')
+    headers = api.get_headers()
+    assert headers['Authorization'] == 'OAuth TOKEN'
+    assert headers['X-Cloud-Org-ID'] == 'ORG'
+
+@pytest.mark.asyncio
+async def test_get_issue():
+    api = TrackerAPI('http://example.com', 'TOKEN')
+    mock_session = MagicMock()
+    mock_session.get.return_value = MockResponse({'key': 'ISSUE-1'})
+    api.get_session = AsyncMock(return_value=mock_session)
+
+    issue = await api.get_issue('ISSUE-1')
+    assert issue['key'] == 'ISSUE-1'
+
+@pytest.mark.asyncio
+async def test_get_comment_author():
+    api = TrackerAPI('http://example.com', 'TOKEN')
+    mock_session = MagicMock()
+    mock_session.get.return_value = MockResponse({'createdBy': {'display': 'Tester'}})
+    api.get_session = AsyncMock(return_value=mock_session)
+
+    author = await api.get_comment_author('ISSUE-1', '1')
+    assert author == 'Tester'
+
+@pytest.mark.asyncio
+async def test_get_attachments_for_comment():
+    api = TrackerAPI('http://example.com', 'TOKEN')
+    mock_session = MagicMock()
+    mock_session.get.return_value = MockResponse({
+        'attachments': [
+            {
+                'fileName': 'file.txt',
+                'urls': {'download': 'http://files/file.txt'}
+            }
+        ]
+    })
+    api.get_session = AsyncMock(return_value=mock_session)
+
+    atts = await api.get_attachments_for_comment('ISSUE-1', '1')
+    assert atts[0]['filename'] == 'file.txt'
+    assert 'http://' in atts[0]['content_url']

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -35,7 +35,8 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
 
         comment_author = await tracker.get_comment_author(issue_key, comment_id)
 
-        telegram_id = tracker.get_issue(issue_key).get("telegramId")
+        issue_info = await tracker.get_issue(issue_key)
+        telegram_id = issue_info.get("telegramId")
         if not telegram_id:
             logging.warning(f"❌ Не найден telegramId для задачи {issue_key}")
             return {"status": "ignored"}
@@ -51,7 +52,7 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
                 content_url = att["content_url"]
                 filename = att["filename"]
                 
-                async with session.get(content_url, headers=tracker.headers) as resp:
+                async with session.get(content_url, headers=tracker.get_headers()) as resp:
                     if resp.status != 200:
                         logging.error(f"Ошибка загрузки файла {filename}: {resp.status}")
                         continue


### PR DESCRIPTION
## Summary
- provide `get_headers` helper and comment/issue retrieval functions
- update webhook to use new tracker methods
- add basic tests for new TrackerAPI methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684803055558832bafa48e5bc09f3714