### PR TITLE
Restore registration flow

### DIFF
--- a/handlers_common.py
+++ b/handlers_common.py
@@ -47,9 +47,16 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if user_info:
         await show_main_reply_menu(update, context)
         return ConversationHandler.END
-    # ... логика регистрации ...
-    # После успешной регистрации тоже вызвать:
-    # await show_main_reply_menu(update, context)
+
+    # Пользователь не найден в БД – просим отправить контакт
+    if update.message:
+        await safe_reply_text(
+            update.message,
+            "Чтобы продолжить, поделитесь контактом:",
+            reply_markup=contact_keyboard(),
+        )
+        await safe_delete_message(update.message)
+    return RegistrationStates.waiting_for_contact
 
 async def show_user_info(update, context):
     db = context.bot_data["db"]
@@ -85,8 +92,8 @@ async def process_contact(update: Update, context: CallbackContext):
         contact.phone_number,
     )
 
-    # После регистрации показываем главное меню.
-    await main_menu(update, context)
+    await safe_reply_text(update.message, "✅ Регистрация успешна!")
+    await show_main_reply_menu(update, context)
     return ConversationHandler.END
 
 


### PR DESCRIPTION
## Summary
- request contact on `/start` when the user isn't in DB
- notify the user once the contact is saved and show menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481d3f5c68832b8d873bfd040e9277