### PR TITLE
Fix send_message calls

### DIFF
--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -225,7 +225,7 @@ async def _process_album_later(group_id: str, context: CallbackContext):
     context.user_data["attachments"] = context.user_data.get("attachments", []) + attachments
 
     await context.bot.send_message(
-        chat_id,
+        chat_id=chat_id,
         text=f"📎 Загружено файлов: {len(attachments)}. Добавьте ещё или нажмите 📤 Создать задачу.",
         reply_markup=InlineKeyboardMarkup([
             [InlineKeyboardButton("📤 Создать задачу", callback_data="create_issue")],

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -103,7 +103,11 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
             for doc in documents:
                 await application.bot.send_document(chat_id, doc)
             
-            await application.bot.send_message(chat_id, message_text, parse_mode="HTML")
+            await application.bot.send_message(
+                chat_id=chat_id,
+                text=message_text,
+                parse_mode="HTML",
+            )
         except Exception as e:
             logging.error(f"❌ Ошибка при отправке сообщений в Telegram: {e}")
         


### PR DESCRIPTION
## Summary
- avoid positional arguments when calling `send_message`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852666f01b8832ba540303873bca551