### PR TITLE
Fix duplicate deletion

### DIFF
--- a/handlers_common.py
+++ b/handlers_common.py
@@ -37,7 +37,6 @@ async def show_main_reply_menu(update: Update, context: ContextTypes.DEFAULT_TYP
             reply_markup=main_reply_keyboard()
         )
         await safe_delete_message(update.message)
-        await safe_delete_message(update.message)
 
 # ────────────────────────── /start  ─────────────────────────────
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):


### PR DESCRIPTION
## Summary
- remove second `safe_delete_message` in `show_main_reply_menu`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68526676e318832bb5eecf0a7297ded7