### PR TITLE
Fix to use logging for version info

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from httpx import Limits
 from telegram.request import HTTPXRequest
 from telegram.ext import ApplicationBuilder
 import telegram
-print("python-telegram-bot version:", telegram.__version__)
+logging.info("python-telegram-bot version: %s", telegram.__version__)
 
 
 from config import Config


### PR DESCRIPTION
## Summary
- log python-telegram-bot version instead of printing it

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852667c38f0832bad1f0a8dbf222588