### PR TITLE
Fix FastAPI import

### DIFF
--- a/webhook_server.py
+++ b/webhook_server.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Request, Depends, HTTPException
+from fastapi import FastAPI, APIRouter, Request, Depends, HTTPException
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import logging
 import asyncio


### PR DESCRIPTION
## Summary
- fix missing `FastAPI` import in `webhook_server.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685288b4fffc832b9efaa0140fb93049