### PR TITLE
Fix run_polling loop closure issue

### DIFF
--- a/main.py
+++ b/main.py
@@ -110,7 +110,7 @@ async def main() -> None:
     # ───── параллельный запуск ─────
     try:
         await asyncio.gather(
-            application.run_polling(),
+            asyncio.to_thread(application.run_polling, close_loop=False),
             run_webhook_server(args.host, args.port),
         )
     finally:


### PR DESCRIPTION
## Summary
- run the blocking `run_polling` call in a thread and disable internal loop closing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b4c920b0832ba0ee2d217ea5fe8f