### PR TITLE
Fix signal handler runtime error

### DIFF
--- a/main.py
+++ b/main.py
@@ -110,7 +110,11 @@ async def main() -> None:
     # ───── параллельный запуск ─────
     try:
         await asyncio.gather(
-            asyncio.to_thread(application.run_polling, close_loop=False),
+            asyncio.to_thread(
+                application.run_polling,
+                close_loop=False,
+                stop_signals=None,
+            ),
             run_webhook_server(args.host, args.port),
         )
     finally:


### PR DESCRIPTION
## Summary
- disable signal handlers when running polling in a thread

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b57eac4c832bad5bcf775424a49d