### PR TITLE
Support telegramId in webhook payload

### DIFF
--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -1,0 +1,76 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, MagicMock
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from webhook_server import setup_webhook_routes, router
+from config import Config
+
+
+def create_app(bot, tracker):
+    app = FastAPI()
+    router.routes.clear()
+    setup_webhook_routes(app, bot, tracker)
+    return app
+
+
+def create_mocks(telegram_id=None):
+    bot = MagicMock()
+    bot.send_media_group = AsyncMock()
+    bot.send_document = AsyncMock()
+
+    tracker = MagicMock()
+    tracker.get_issue = AsyncMock(return_value={"telegramId": telegram_id})
+    tracker.get_attachments_for_comment = AsyncMock(return_value=[])
+    tracker.get_session = AsyncMock(return_value=MagicMock())
+    tracker.get_comment_author = AsyncMock(return_value="Tester")
+    return bot, tracker
+
+
+def test_receive_webhook_with_telegram_id():
+    Config.API_TOKEN = "TOKEN"
+    bot, tracker = create_mocks()
+    app = create_app(bot, tracker)
+    client = TestClient(app)
+
+    payload = {
+        "event": "commentCreated",
+        "issue": {"key": "ISSUE-1", "summary": "Test", "telegramId": "123"},
+        "comment": {"id": "1", "text": "hi", "createdBy": {"display": "Tester"}},
+    }
+
+    response = client.post(
+        "/trackers/comment",
+        json=payload,
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    tracker.get_issue.assert_not_called()
+
+
+def test_receive_webhook_fallback_to_get_issue():
+    Config.API_TOKEN = "TOKEN"
+    bot, tracker = create_mocks(telegram_id="321")
+    app = create_app(bot, tracker)
+    client = TestClient(app)
+
+    payload = {
+        "event": "commentCreated",
+        "issue": {"key": "ISSUE-1", "summary": "Test"},
+        "comment": {"id": "1", "text": "hi", "createdBy": {"display": "Tester"}},
+    }
+
+    response = client.post(
+        "/trackers/comment",
+        json=payload,
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    tracker.get_issue.assert_called_once_with("ISSUE-1")

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -35,6 +35,8 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
         comment_id = comment_data.get("id")
         issue_summary = issue.get("summary", "Нет темы")
 
+        telegram_id = issue.get("telegramId")
+
         comment_author = comment_data.get("createdBy", {}).get("display")
         if not comment_author:
             try:
@@ -43,12 +45,14 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
                 logging.error(f"Не удалось получить автора комментария: {exc}")
                 comment_author = "неизвестен"
 
-        try:
-            issue_info = await tracker.get_issue(issue_key)
-        except Exception as exc:
-            logging.error(f"Не удалось получить информацию о задаче: {exc}")
-            return {"status": "error"}
-        telegram_id = issue_info.get("telegramId")
+        issue_info = None
+        if not telegram_id:
+            try:
+                issue_info = await tracker.get_issue(issue_key)
+            except Exception as exc:
+                logging.error(f"Не удалось получить информацию о задаче: {exc}")
+                return {"status": "error"}
+            telegram_id = issue_info.get("telegramId")
         if not telegram_id:
             logging.warning(f"❌ Не найден telegramId для задачи {issue_key}")
             return {"status": "ignored"}


### PR DESCRIPTION
## Summary
- handle `telegramId` in webhook payload before falling back to Tracker API
- add tests for webhook comment webhook handler

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852bb4a16bc832ba0c24d558aa58477