### PR TITLE
Fix loop conflict when running bot alongside webhook

### DIFF
--- a/main.py
+++ b/main.py
@@ -107,18 +107,16 @@ async def main() -> None:
 
     logging.info("🤖 Бот (polling) и FastAPI‑webhook стартуют…")
 
-    # ───── параллельный запуск ─────
+    # ───── запуск приложения и вебхука в одном event loop ─────
     try:
-        await asyncio.gather(
-            asyncio.to_thread(
-                application.run_polling,
-                close_loop=False,
-                stop_signals=None,
-            ),
-            run_webhook_server(args.host, args.port),
-        )
+        await application.initialize()
+        await application.start()
+        await application.updater.start_polling()
+        await run_webhook_server(args.host, args.port)
     finally:
-        # закрываем ресурсы
+        await application.updater.stop()
+        await application.stop()
+        await application.shutdown()
         await tracker.close()
         await db.close()
         logging.info("✅ Завершение работы: ресурсы освобождены")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv
 uvicorn
 nest_asyncio
 pytest-asyncio
+httpx<0.28


### PR DESCRIPTION
## Summary
- handle polling and webhook server in the same event loop
- pin httpx to <0.28 for test compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852bd338ac0832b8e8bac1e8be748e6