### PR TITLE
Add log when bot is running

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,6 +50,7 @@ async def start_webhook_server(host: str, port: int):
     """Запускает FastAPI‑сервер и возвращает ``Server`` и задачу его работы."""
     config = uvicorn.Config(app=fastapi_app, host=host, port=port, log_level="info")
     server = uvicorn.Server(config)
+    logging.info("🌐 FastAPI сервер запускается на http://%s:%d", host, port)
     server_task = asyncio.create_task(server.serve())
     return server, server_task
 
@@ -114,19 +115,23 @@ async def main() -> None:
         await application.initialize()
         await application.start()
         await application.updater.start_polling()
+        logging.info("✅ Бот запущен и ожидает события")
 
         server, server_task = await start_webhook_server(args.host, args.port)
         await server_task
+        logging.info("✅ FastAPI сервер завершил работу")
     except KeyboardInterrupt:
         logging.info("🛑 Keyboard interrupt received. Shutting down…")
     finally:
         await application.updater.stop()
+        logging.info("✅ Бот остановлен")
         await application.stop()
         await application.shutdown()
         if 'server' in locals():
             server.should_exit = True
             with contextlib.suppress(Exception):
                 await server_task
+            logging.info("✅ FastAPI сервер остановлен")
         await tracker.close()
         await db.close()
         logging.info("✅ Завершение работы: ресурсы освобождены")


### PR DESCRIPTION
## Summary
- add log when the Telegram bot is ready
- log bot shutdown as well

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852c9ca5c64832b85eb298f0fe5fe85