### PR TITLE
Handle missing comment id

### DIFF
--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -10,10 +10,10 @@ from webhook_server import setup_webhook_routes, router
 from config import Config
 
 
-def create_app(bot, tracker):
+def create_app(application, tracker):
     app = FastAPI()
     router.routes.clear()
-    setup_webhook_routes(app, bot, tracker)
+    setup_webhook_routes(app, application, tracker)
     return app
 
 
@@ -21,19 +21,23 @@ def create_mocks(telegram_id=None):
     bot = MagicMock()
     bot.send_media_group = AsyncMock()
     bot.send_document = AsyncMock()
+    bot.send_message = AsyncMock()
+
+    application = MagicMock()
+    application.bot = bot
 
     tracker = MagicMock()
     tracker.get_issue = AsyncMock(return_value={"telegramId": telegram_id})
     tracker.get_attachments_for_comment = AsyncMock(return_value=[])
     tracker.get_session = AsyncMock(return_value=MagicMock())
     tracker.get_comment_author = AsyncMock(return_value="Tester")
-    return bot, tracker
+    return application, tracker, bot
 
 
 def test_receive_webhook_with_telegram_id():
     Config.API_TOKEN = "TOKEN"
-    bot, tracker = create_mocks()
-    app = create_app(bot, tracker)
+    application, tracker, bot = create_mocks()
+    app = create_app(application, tracker)
     client = TestClient(app)
 
     payload = {
@@ -51,12 +55,16 @@ def test_receive_webhook_with_telegram_id():
     assert response.status_code == 200
     assert response.json()["status"] == "ok"
     tracker.get_issue.assert_not_called()
+    bot.send_message.assert_called_once()
+    kwargs = bot.send_message.call_args.kwargs
+    assert kwargs["chat_id"] == 123
+    assert kwargs["parse_mode"] == "HTML"
 
 
 def test_receive_webhook_fallback_to_get_issue():
     Config.API_TOKEN = "TOKEN"
-    bot, tracker = create_mocks(telegram_id="321")
-    app = create_app(bot, tracker)
+    application, tracker, bot = create_mocks(telegram_id="321")
+    app = create_app(application, tracker)
     client = TestClient(app)
 
     payload = {
@@ -74,3 +82,33 @@ def test_receive_webhook_fallback_to_get_issue():
     assert response.status_code == 200
     assert response.json()["status"] == "ok"
     tracker.get_issue.assert_called_once_with("ISSUE-1")
+    bot.send_message.assert_called_once()
+    kwargs = bot.send_message.call_args.kwargs
+    assert kwargs["chat_id"] == 321
+
+
+def test_receive_webhook_without_comment_id():
+    Config.API_TOKEN = "TOKEN"
+    application, tracker, bot = create_mocks(telegram_id="123")
+    app = create_app(application, tracker)
+    client = TestClient(app)
+
+    payload = {
+        "event": "commentCreated",
+        "issue": {"key": "ISSUE-1", "summary": "Test", "telegramId": "123"},
+        "comment": {"text": "hi"},
+    }
+
+    response = client.post(
+        "/trackers/comment",
+        json=payload,
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    tracker.get_comment_author.assert_not_called()
+    tracker.get_attachments_for_comment.assert_not_called()
+    bot.send_message.assert_called_once()
+    kwargs = bot.send_message.call_args.kwargs
+    assert kwargs["chat_id"] == 123


### PR DESCRIPTION
## Summary
- handle missing comment ID in webhook
- add regression test
- send comment messages with reply buttons to allow adding tracker replies from Telegram

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6852d6d2bc74832b83128bab7b29cf02