### PR TITLE
Fix webhook route setup

### DIFF
--- a/main.py
+++ b/main.py
@@ -107,7 +107,7 @@ async def main() -> None:
     register_issue_handlers(application)
 
     # ───── FastAPI маршруты вебхука ─────
-    setup_webhook_routes(fastapi_app, application.bot, tracker)
+    setup_webhook_routes(fastapi_app, application, tracker)
 
     logging.info("🤖 Бот (polling) и FastAPI‑webhook стартуют…")
 


### PR DESCRIPTION
## Summary
- pass the Telegram application to webhook server setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853be75d334832ba03fbba96d3e0c4a