### PR TITLE
Fix graceful shutdown error

### DIFF
--- a/main.py
+++ b/main.py
@@ -130,7 +130,9 @@ async def main() -> None:
         await application.shutdown()
         if 'server' in locals():
             server.should_exit = True
-            with contextlib.suppress(Exception):
+            # ``server_task`` could raise ``KeyboardInterrupt`` or ``CancelledError``
+            # during shutdown, which should be ignored to finish gracefully
+            with contextlib.suppress(Exception, asyncio.CancelledError, KeyboardInterrupt):
                 await server_task
             logging.info("✅ FastAPI сервер остановлен")
         await tracker.close()


### PR DESCRIPTION
## Summary
- ensure FastAPI server shutdown doesn't surface CancelledError or KeyboardInterrupt

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685418596b4c832bb4a4f550aaf2b97d