### PR TITLE
Optimize HTTP connections for faster responses

### DIFF
--- a/main.py
+++ b/main.py
@@ -74,11 +74,13 @@ async def main() -> None:
     # ───── создаём Telegram‑Application ─────
     application = ApplicationBuilder()\
         .token(BOT_TOKEN)\
-        .request(HTTPXRequest(
-            read_timeout=60,
-            connect_timeout=30
-            # без pool_limits!
-        ))\
+        .request(
+            HTTPXRequest(
+                read_timeout=60,
+                connect_timeout=30,
+                pool_limits=Limits(max_connections=20, max_keepalive_connections=10),
+            )
+        )\
         .build()
 
     application.add_error_handler(error_handler)


### PR DESCRIPTION
## Summary
- reuse `aiohttp` TCP connections in `TrackerAPI`
- enable HTTPX connection pooling for Telegram bot requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854f472bdb8832ba29dfb8c723ea7ca