### PR TITLE
Add tracker project and product defaults

### DIFF
--- a/config.py
+++ b/config.py
@@ -12,6 +12,16 @@ class Config:
     TRACKER_ORG_ID = os.getenv('TRACKER_ORG_ID')
     TRACKER_QUEUE = os.getenv('TRACKER_QUEUE')  # Добавлено
     API_TOKEN = os.getenv('API_TOKEN')  # Добавлено
+
+    # Default values for Tracker issue creation
+    PROJECT = {
+        "self": "https://api.tracker.yandex.net/v2/projects/4",
+        "id": "4",
+        "display": "CRM",
+    }
+    PRODUCT_FIELD_NAME = "67c0879c407b93717eac01e6--product"
+    PRODUCT_VALUE = ["CRM"]
+    DEFAULT_TAGS = ["Запрос"]
     
     # PostgreSQL
     DB_USER = os.getenv('DB_USER')

--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -7,6 +7,7 @@ import html
 from collections import defaultdict
 from typing import Final, List, Dict
 from telegram.ext import ContextTypes, CallbackContext
+from config import Config
 
 from telegram import (
     Update,
@@ -282,7 +283,12 @@ async def confirm_issue_creation(update: Update, context: CallbackContext):
         f"🔗 @{user.username or 'без username'}"
     )
 
-    extra_fields = {"telegramId": str(user.id)}
+    extra_fields = {
+        "telegramId": str(user.id),
+        "project": Config.PROJECT,
+        Config.PRODUCT_FIELD_NAME: Config.PRODUCT_VALUE,
+        "tags": Config.DEFAULT_TAGS,
+    }
     if attachments:
         # При создании задачи вложения передаются через поле attachmentIds
         extra_fields["attachmentIds"] = attachments

--- a/tests/test_handlers_issue.py
+++ b/tests/test_handlers_issue.py
@@ -1,0 +1,46 @@
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+
+from handlers_issue import confirm_issue_creation
+from config import Config
+
+@pytest.mark.asyncio
+async def test_confirm_issue_creation_extra_fields():
+    update = MagicMock()
+    user = MagicMock()
+    user.id = 1
+    user.first_name = "A"
+    user.last_name = "B"
+    user.username = "user"
+    update.effective_user = user
+
+    query = MagicMock()
+    query.answer = AsyncMock()
+    query.message.reply_text = AsyncMock()
+    update.callback_query = query
+
+    context = MagicMock()
+    context.user_data = {
+        "issue_title": "Title",
+        "issue_description": "Desc",
+        "attachments": [123],
+    }
+    db = MagicMock()
+    db.get_user = AsyncMock(return_value={"phone_number": "111"})
+    db.create_issue = AsyncMock()
+    tracker = MagicMock()
+    tracker.create_issue = AsyncMock(return_value={"key": "ISSUE-1"})
+    context.bot_data = {"db": db, "tracker": tracker}
+
+    await confirm_issue_creation(update, context)
+
+    extra = tracker.create_issue.call_args.args[2]
+    assert extra["project"] == Config.PROJECT
+    assert extra[Config.PRODUCT_FIELD_NAME] == Config.PRODUCT_VALUE
+    assert extra["tags"] == Config.DEFAULT_TAGS
+    assert extra["attachmentIds"] == [123]


### PR DESCRIPTION
## Summary
- supply default Tracker fields when creating issues
- test that these defaults are used in handlers

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855143d669c832b9e1f0776808396b9