### PR TITLE
Implement product field and filter cancelled issues

### DIFF
--- a/config.py
+++ b/config.py
@@ -23,6 +23,10 @@ class Config:
     # Default tags for created issues
     DEFAULT_TAGS = ["Запрос"]
 
+    # Custom field for product selection
+    PRODUCT_CUSTOM_FIELD = "67c0879c407b93717eac01e6--product"
+    PRODUCT_DEFAULT = ["CRM"]
+
     
     # PostgreSQL
     DB_USER = os.getenv('DB_USER')

--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -287,6 +287,7 @@ async def confirm_issue_creation(update: Update, context: CallbackContext):
         "telegramId": str(user.id),
         "project": Config.PROJECT,
         "tags": Config.DEFAULT_TAGS,
+        Config.PRODUCT_CUSTOM_FIELD: Config.PRODUCT_DEFAULT,
     }
     if attachments:
         # При создании задачи вложения передаются через поле attachmentIds

--- a/tests/test_handlers_issue.py
+++ b/tests/test_handlers_issue.py
@@ -43,3 +43,4 @@ async def test_confirm_issue_creation_extra_fields():
     assert extra["project"] == Config.PROJECT
     assert extra["tags"] == Config.DEFAULT_TAGS
     assert extra["attachmentIds"] == [123]
+    assert extra[Config.PRODUCT_CUSTOM_FIELD] == Config.PRODUCT_DEFAULT

--- a/tests/test_tracker_client.py
+++ b/tests/test_tracker_client.py
@@ -74,6 +74,22 @@ async def test_get_attachments_for_comment():
     assert 'http://' in atts[0]['content_url']
 
 
+@pytest.mark.asyncio
+async def test_get_active_issues_filters_statuses():
+    api = TrackerAPI('http://example.com', 'TOKEN', queue='CRM')
+    mock_session = MagicMock()
+    mock_session.post.return_value = MockResponse([
+        {'key': 'ISSUE-1', 'status': {'key': 'open'}},
+        {'key': 'ISSUE-2', 'status': {'key': 'closed'}},
+        {'key': 'ISSUE-3', 'status': {'key': 'canceled'}},
+    ])
+    api.get_session = AsyncMock(return_value=mock_session)
+
+    issues = await api.get_active_issues_by_telegram_id(1)
+    keys = [i['key'] for i in issues]
+    assert keys == ['ISSUE-1']
+
+
 def test_normalize_comment_id():
     api = TrackerAPI('http://example.com', 'TOKEN')
     assert api._normalize_comment_id('123') == 123

--- a/tracker_client.py
+++ b/tracker_client.py
@@ -157,10 +157,11 @@ class TrackerAPI:
                 raise Exception(f"Search issues failed: {resp.status} {text}")
             issues = await resp.json()
 
-        # Фильтруем закрытые задачи вручную
+        # Фильтруем закрытые и отменённые задачи вручную
         filtered = [
-            issue for issue in issues
-            if issue.get("status", {}).get("key") != "closed"
+            issue
+            for issue in issues
+            if issue.get("status", {}).get("key") not in {"closed", "canceled"}
         ]
         return filtered
 

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -128,6 +128,10 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
                         logging.error("Не удалось удалить временный файл %s: %s", path, exc)
             for doc, path in documents:
                 await application.bot.send_document(chat_id, doc)
+                try:
+                    os.remove(path)
+                except OSError as exc:
+                    logging.error("Не удалось удалить временный файл %s: %s", path, exc)
 
         except Exception as e:
             logging.error(f"❌ Ошибка при отправке сообщений в Telegram: {e}")


### PR DESCRIPTION
## Summary
- support product custom field when creating Tracker issues
- filter out cancelled issues in TrackerAPI
- clean up downloaded files from Tracker webhooks
- adjust tests for new product field
- test filtering logic

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68553081bf68832bae4f9b1757267772