### PR TITLE
Fix attachments without filename

### DIFF
--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -34,6 +34,21 @@ def create_mocks(telegram_id=None):
     return application, tracker, bot
 
 
+class DummyResp:
+    def __init__(self, data=b"", status=200):
+        self._data = data
+        self.status = status
+
+    async def read(self):
+        return self._data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
 def test_receive_webhook_with_telegram_id():
     Config.API_TOKEN = "TOKEN"
     application, tracker, bot = create_mocks()
@@ -167,3 +182,40 @@ def test_update_status_fallback_to_get_issue():
     bot.send_message.assert_called_once()
     kwargs = bot.send_message.call_args.kwargs
     assert kwargs["chat_id"] == 456
+
+
+def test_receive_webhook_skips_invalid_attachments():
+    Config.API_TOKEN = "TOKEN"
+    application, tracker, bot = create_mocks()
+
+    tracker.get_attachments_for_comment = AsyncMock(
+        return_value=[
+            {"content_url": "http://files/file1.txt", "filename": None},
+            {"content_url": None, "filename": "file2.txt"},
+        ]
+    )
+
+    mock_session = MagicMock()
+    mock_session.get.return_value = DummyResp()
+    tracker.get_session = AsyncMock(return_value=mock_session)
+
+    app = create_app(application, tracker)
+    client = TestClient(app)
+
+    payload = {
+        "event": "commentCreated",
+        "issue": {"key": "ISSUE-1", "summary": "Test", "telegramId": "123"},
+        "comment": {"id": "1", "text": "hi"},
+    }
+
+    response = client.post(
+        "/trackers/comment",
+        json=payload,
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    bot.send_message.assert_called_once()
+    bot.send_document.assert_not_called()
+    bot.send_media_group.assert_not_called()

--- a/tracker_client.py
+++ b/tracker_client.py
@@ -135,7 +135,14 @@ class TrackerAPI:
             if isinstance(att.get("urls"), dict):
                 content_url = att["urls"].get("download") or att["urls"].get("self")
             content_url = content_url or att.get("contentUrl") or att.get("self")
-            filename = att.get("fileName") or att.get("name") or att.get("filename")
+            filename = (
+                att.get("fileName")
+                or att.get("name")
+                or att.get("filename")
+            )
+            if not content_url or not filename:
+                logger.warning("Skip attachment without filename or content url: %s", att)
+                continue
             attachments.append({"content_url": content_url, "filename": filename})
         return attachments
 

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -72,8 +72,11 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
         session = await tracker.get_session()
 
         async def download_attachment(att):
-            content_url = att["content_url"]
-            filename = att["filename"]
+            content_url = att.get("content_url")
+            filename = att.get("filename")
+            if not content_url or not filename:
+                logging.warning("Некорректные данные вложения: %s", att)
+                return None
             async with session.get(content_url, headers=tracker.get_headers()) as resp:
                 if resp.status != 200:
                     logging.error(f"Ошибка загрузки файла {filename}: {resp.status}")


### PR DESCRIPTION
## Summary
- handle attachments lacking filename or content url
- warn and skip malformed attachments
- test edge cases for bad attachments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68553311e358832b9c1c5fdfad69ed0b