### PR TITLE
Fix attachments without filename

### DIFF
--- a/tests/test_tracker_client.py
+++ b/tests/test_tracker_client.py
@@ -75,6 +75,25 @@ async def test_get_attachments_for_comment():
 
 
 @pytest.mark.asyncio
+async def test_get_attachments_for_comment_display_name():
+    api = TrackerAPI('http://example.com', 'TOKEN')
+    mock_session = MagicMock()
+    mock_session.get.return_value = MockResponse({
+        'attachments': [
+            {
+                'display': 'image.png',
+                'self': 'http://files/image.png'
+            }
+        ]
+    })
+    api.get_session = AsyncMock(return_value=mock_session)
+
+    atts = await api.get_attachments_for_comment('ISSUE-1', '1')
+    assert atts[0]['filename'] == 'image.png'
+    assert atts[0]['content_url'].endswith('/download')
+
+
+@pytest.mark.asyncio
 async def test_get_active_issues_filters_statuses():
     api = TrackerAPI('http://example.com', 'TOKEN', queue='CRM')
     mock_session = MagicMock()

--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -6,13 +6,14 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-from webhook_server import setup_webhook_routes, router
+from webhook_server import setup_webhook_routes, router, processed_comment_ids
 from config import Config
 
 
 def create_app(application, tracker):
     app = FastAPI()
     router.routes.clear()
+    processed_comment_ids.clear()
     setup_webhook_routes(app, application, tracker)
     return app
 
@@ -32,6 +33,21 @@ def create_mocks(telegram_id=None):
     tracker.get_session = AsyncMock(return_value=MagicMock())
     tracker.get_comment_author = AsyncMock(return_value="Tester")
     return application, tracker, bot
+
+
+class DummyResp:
+    def __init__(self, data=b"", status=200):
+        self._data = data
+        self.status = status
+
+    async def read(self):
+        return self._data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
 
 
 def test_receive_webhook_with_telegram_id():
@@ -167,3 +183,142 @@ def test_update_status_fallback_to_get_issue():
     bot.send_message.assert_called_once()
     kwargs = bot.send_message.call_args.kwargs
     assert kwargs["chat_id"] == 456
+
+
+def test_receive_webhook_skips_invalid_attachments():
+    Config.API_TOKEN = "TOKEN"
+    application, tracker, bot = create_mocks()
+
+    tracker.get_attachments_for_comment = AsyncMock(
+        return_value=[
+            {"content_url": "http://files/file1.txt", "filename": None},
+            {"content_url": None, "filename": "file2.txt"},
+        ]
+    )
+
+    mock_session = MagicMock()
+    mock_session.get.return_value = DummyResp()
+    tracker.get_session = AsyncMock(return_value=mock_session)
+
+    app = create_app(application, tracker)
+    client = TestClient(app)
+
+    payload = {
+        "event": "commentCreated",
+        "issue": {"key": "ISSUE-1", "summary": "Test", "telegramId": "123"},
+        "comment": {"id": "1", "text": "hi"},
+    }
+
+    response = client.post(
+        "/trackers/comment",
+        json=payload,
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    bot.send_message.assert_called_once()
+    bot.send_document.assert_not_called()
+    bot.send_media_group.assert_not_called()
+
+
+def test_receive_webhook_handles_display_attachment():
+    Config.API_TOKEN = "TOKEN"
+    application, tracker, bot = create_mocks()
+
+    tracker.get_attachments_for_comment = AsyncMock(
+        return_value=[
+            {"content_url": "http://files/image.png", "filename": "image.png"},
+            {"content_url": "http://files/doc.txt", "filename": "doc.txt"},
+        ]
+    )
+
+    mock_session = MagicMock()
+    mock_session.get.return_value = DummyResp()
+    tracker.get_session = AsyncMock(return_value=mock_session)
+
+    app = create_app(application, tracker)
+    client = TestClient(app)
+
+    payload = {
+        "event": "commentCreated",
+        "issue": {"key": "ISSUE-1", "summary": "Test", "telegramId": "123"},
+        "comment": {"id": "1", "text": "hi"},
+    }
+
+    response = client.post(
+        "/trackers/comment",
+        json=payload,
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+
+    assert response.status_code == 200
+    bot.send_media_group.assert_called_once()
+    bot.send_document.assert_called_once()
+
+
+def test_receive_webhook_strips_image_links():
+    Config.API_TOKEN = "TOKEN"
+    application, tracker, bot = create_mocks()
+
+    tracker.get_attachments_for_comment = AsyncMock(return_value=[])
+    mock_session = MagicMock()
+    mock_session.get.return_value = DummyResp()
+    tracker.get_session = AsyncMock(return_value=mock_session)
+
+    app = create_app(application, tracker)
+    client = TestClient(app)
+
+    payload = {
+        "event": "commentCreated",
+        "issue": {"key": "ISSUE-1", "summary": "Test", "telegramId": "123"},
+        "comment": {
+            "id": "1",
+            "text": "Hello ![image.png](/ajax/v2/attachments/1 =800x600) there",
+        },
+    }
+
+    response = client.post(
+        "/trackers/comment",
+        json=payload,
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+
+    assert response.status_code == 200
+    sent_text = bot.send_message.call_args.kwargs["text"]
+    assert "![" not in sent_text
+    assert "Hello" in sent_text
+
+
+def test_receive_webhook_deduplicates_comment():
+    Config.API_TOKEN = "TOKEN"
+    application, tracker, bot = create_mocks()
+
+    tracker.get_attachments_for_comment = AsyncMock(return_value=[])
+    mock_session = MagicMock()
+    mock_session.get.return_value = DummyResp()
+    tracker.get_session = AsyncMock(return_value=mock_session)
+
+    app = create_app(application, tracker)
+    client = TestClient(app)
+
+    payload = {
+        "event": "commentCreated",
+        "issue": {"key": "ISSUE-1", "summary": "Test", "telegramId": "123"},
+        "comment": {"id": "1", "text": "hi"},
+    }
+
+    response1 = client.post(
+        "/trackers/comment",
+        json=payload,
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+    response2 = client.post(
+        "/trackers/comment",
+        json=payload,
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+
+    assert response1.status_code == 200
+    assert response2.status_code == 200
+    bot.send_message.assert_called_once()

--- a/tracker_client.py
+++ b/tracker_client.py
@@ -135,7 +135,17 @@ class TrackerAPI:
             if isinstance(att.get("urls"), dict):
                 content_url = att["urls"].get("download") or att["urls"].get("self")
             content_url = content_url or att.get("contentUrl") or att.get("self")
-            filename = att.get("fileName") or att.get("name") or att.get("filename")
+            if att.get("self") and (not content_url or content_url == att["self"]):
+                content_url = f"{att['self']}/download"
+            filename = (
+                att.get("fileName")
+                or att.get("name")
+                or att.get("filename")
+                or att.get("display")
+            )
+            if not content_url or not filename:
+                logger.warning("Skip attachment without filename or content url: %s", att)
+                continue
             attachments.append({"content_url": content_url, "filename": filename})
         return attachments
 

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, APIRouter, Request, Depends, HTTPException
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import logging
 import asyncio
+import re
 from telegram import InputMediaPhoto, InputFile, InlineKeyboardButton, InlineKeyboardMarkup
 from messages import WEBHOOK_COMMENT, WEBHOOK_STATUS
 from telegram.ext import Application
@@ -13,6 +14,20 @@ app = FastAPI()
 
 router = APIRouter()
 bearer_scheme = HTTPBearer()
+
+# In-memory store of processed comment IDs to prevent duplicates
+processed_comment_ids: set[str] = set()
+
+# Regex to strip markdown image links like ![alt](url)
+IMAGE_LINK_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+
+def strip_image_links(text: str) -> str:
+    """Remove markdown image links from text."""
+    if not text:
+        return ""
+    cleaned = IMAGE_LINK_RE.sub("", text)
+    cleaned = re.sub(r"\s{2,}", " ", cleaned)
+    return cleaned.strip()
 
 def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
     """Настраивает маршруты вебхуков"""
@@ -35,6 +50,12 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
         issue_key = issue.get("key")
         comment_id = comment_data.get("id")
         issue_summary = issue.get("summary", "Нет темы")
+
+        if comment_id and comment_id in processed_comment_ids:
+            logging.info("Duplicate comment %s ignored", comment_id)
+            return {"status": "ignored"}
+        if comment_id:
+            processed_comment_ids.add(str(comment_id))
 
         telegram_id = issue.get("telegramId")
 
@@ -72,8 +93,11 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
         session = await tracker.get_session()
 
         async def download_attachment(att):
-            content_url = att["content_url"]
-            filename = att["filename"]
+            content_url = att.get("content_url")
+            filename = att.get("filename")
+            if not content_url or not filename:
+                logging.warning("Некорректные данные вложения: %s", att)
+                return None
             async with session.get(content_url, headers=tracker.get_headers()) as resp:
                 if resp.status != 200:
                     logging.error(f"Ошибка загрузки файла {filename}: {resp.status}")
@@ -99,10 +123,11 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
             else:
                 documents.append((tg_file, file_path))
         
+        clean_text = strip_image_links(comment_data.get("text", ""))
         message_text = WEBHOOK_COMMENT.format(
             issue_key=issue_key,
             issue_summary=issue_summary,
-            text=comment_data.get('text', ''),
+            text=clean_text,
             author=comment_author,
         )
 


### PR DESCRIPTION
## Summary
- handle attachments lacking filename or content url
- warn and skip malformed attachments
- strip markdown image links from comment text to avoid extra artifacts
- test edge cases for bad attachments and image links
- support attachments with `display` name
- new test for Telegram sending attachments
- deduplicate comment webhooks and generate download links for attachments

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68553311e358832b9c1c5fdfad69ed0b