### PR TITLE
Handle single photo attachments in Telegram webhooks

### DIFF
--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -21,6 +21,7 @@ def create_app(application, tracker):
 def create_mocks(telegram_id=None):
     bot = MagicMock()
     bot.send_media_group = AsyncMock()
+    bot.send_photo = AsyncMock()
     bot.send_document = AsyncMock()
     bot.send_message = AsyncMock()
 
@@ -220,6 +221,7 @@ def test_receive_webhook_skips_invalid_attachments():
     bot.send_message.assert_called_once()
     bot.send_document.assert_not_called()
     bot.send_media_group.assert_not_called()
+    bot.send_photo.assert_not_called()
 
 def test_receive_webhook_handles_display_attachment():
     Config.API_TOKEN = "TOKEN"
@@ -252,7 +254,8 @@ def test_receive_webhook_handles_display_attachment():
     )
 
     assert response.status_code == 200
-    bot.send_media_group.assert_called_once()
+    bot.send_photo.assert_called_once()
+    bot.send_media_group.assert_not_called()
     bot.send_document.assert_called_once()
 
 

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -110,7 +110,7 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
 
             telegram_file = InputFile(file_path)
             if filename.lower().endswith((".jpg", ".png", ".jpeg")):
-                return ("photo", InputMediaPhoto(media=telegram_file), file_path)
+                return ("photo", telegram_file, file_path)
             return ("document", telegram_file, file_path)
 
         download_results = await asyncio.gather(*(download_attachment(att) for att in attachments))
@@ -144,8 +144,11 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
             )
 
             if media_photos:
-                tg_photos = [item[0] for item in media_photos]
-                await application.bot.send_media_group(chat_id, tg_photos)
+                tg_photos = [InputMediaPhoto(media=file) for file, _ in media_photos]
+                if len(tg_photos) > 1:
+                    await application.bot.send_media_group(chat_id, tg_photos)
+                else:
+                    await application.bot.send_photo(chat_id, media_photos[0][0])
                 for _, path in media_photos:
                     try:
                         os.remove(path)


### PR DESCRIPTION
## Summary
- switch to `send_photo` for single images in webhook replies
- refactor attachment download to keep raw `InputFile` objects

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855516d1f1c832b99a9b8d756e95ab4