### PR TITLE
Handle Telegram image processing errors

### DIFF
--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from unittest.mock import AsyncMock, MagicMock
+from telegram.error import BadRequest
 import os
 import sys
 
@@ -237,6 +238,41 @@ def test_receive_webhook_handles_display_attachment():
     mock_session = MagicMock()
     mock_session.get.return_value = DummyResp()
     tracker.get_session = AsyncMock(return_value=mock_session)
+
+    app = create_app(application, tracker)
+    client = TestClient(app)
+
+    payload = {
+        "event": "commentCreated",
+        "issue": {"key": "ISSUE-1", "summary": "Test", "telegramId": "123"},
+        "comment": {"id": "1", "text": "hi"},
+    }
+
+    response = client.post(
+        "/trackers/comment",
+        json=payload,
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+
+    assert response.status_code == 200
+    bot.send_photo.assert_called_once()
+    bot.send_media_group.assert_not_called()
+    bot.send_document.assert_called_once()
+
+
+def test_send_photo_fallbacks_to_document():
+    Config.API_TOKEN = "TOKEN"
+    application, tracker, bot = create_mocks()
+
+    tracker.get_attachments_for_comment = AsyncMock(
+        return_value=[{"content_url": "http://files/image.png", "filename": "image.png"}]
+    )
+
+    mock_session = MagicMock()
+    mock_session.get.return_value = DummyResp()
+    tracker.get_session = AsyncMock(return_value=mock_session)
+
+    bot.send_photo.side_effect = BadRequest("Image_process_failed")
 
     app = create_app(application, tracker)
     client = TestClient(app)

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -4,6 +4,7 @@ import logging
 import asyncio
 import re
 from telegram import InputMediaPhoto, InputFile, InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.error import BadRequest
 from messages import WEBHOOK_COMMENT, WEBHOOK_STATUS
 from telegram.ext import Application
 from config import Config
@@ -145,16 +146,28 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
 
             if media_photos:
                 tg_photos = [InputMediaPhoto(media=file) for file, _ in media_photos]
-                if len(tg_photos) > 1:
-                    await application.bot.send_media_group(chat_id, tg_photos)
-                else:
-                    await application.bot.send_photo(chat_id, media_photos[0][0])
-
-                for _, path in media_photos:
-                    try:
-                        os.remove(path)
-                    except OSError as exc:
-                        logging.error("Не удалось удалить временный файл %s: %s", path, exc)
+                try:
+                    if len(tg_photos) > 1:
+                        await application.bot.send_media_group(chat_id, tg_photos)
+                    else:
+                        await application.bot.send_photo(chat_id, tg_photos[0].media)
+                except BadRequest as exc:
+                    message = getattr(exc, "message", str(exc)).lower()
+                    if "image_process_failed" in message:
+                        logging.warning(
+                            "Image failed to process, sending as documents: %s",
+                            exc,
+                        )
+                        for doc, _ in media_photos:
+                            await application.bot.send_document(chat_id, doc)
+                    else:
+                        raise
+                finally:
+                    for _, path in media_photos:
+                        try:
+                            os.remove(path)
+                        except OSError as exc:
+                            logging.error("Не удалось удалить временный файл %s: %s", path, exc)
             for doc, path in documents:
                 await application.bot.send_document(chat_id, doc)
                 try:


### PR DESCRIPTION
## Summary
- catch BadRequest errors from Telegram when sending photos
- fallback to sending as document if Telegram can't process the photo
- test fallback on image error
- handle the error check case-insensitively

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855b72e70b4832b8201b36d7e9dd5d3