### PR TITLE
Improve attachment handling

### DIFF
--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -426,7 +426,7 @@ def test_download_attachment_sanitizes_filename(monkeypatch):
     captured_paths = []
 
     class DummyInputFile:
-        def __init__(self, path):
+        def __init__(self, path, filename=None):
             captured_paths.append(path)
 
     monkeypatch.setattr(sys.modules["webhook_server"], "InputFile", DummyInputFile)
@@ -447,5 +447,57 @@ def test_download_attachment_sanitizes_filename(monkeypatch):
     )
 
     assert response.status_code == 200
-    assert captured_paths and captured_paths[0] == "/tmp/evil.txt"
+    assert captured_paths
+    basename = os.path.basename(captured_paths[0])
+    assert basename.endswith("_evil.txt")
     assert not os.path.exists(captured_paths[0])
+
+
+def test_download_attachment_unique_paths(monkeypatch):
+    Config.API_TOKEN = "TOKEN"
+    application, tracker, bot = create_mocks()
+
+    tracker.get_attachments_for_comment = AsyncMock(
+        return_value=[
+            {"content_url": "http://files/doc1.txt", "filename": "same.txt"},
+            {"content_url": "http://files/doc2.txt", "filename": "same.txt"},
+        ]
+    )
+
+    mock_session = MagicMock()
+    mock_session.get.return_value = DummyResp(b"data")
+    tracker.get_session = AsyncMock(return_value=mock_session)
+
+    captured = []
+
+    class DummyInputFile:
+        def __init__(self, path, filename=None):
+            captured.append((path, filename))
+
+    monkeypatch.setattr(sys.modules["webhook_server"], "InputFile", DummyInputFile)
+
+    app = create_app(application, tracker)
+    client = TestClient(app)
+
+    payload = {
+        "event": "commentCreated",
+        "issue": {"key": "ISSUE-1", "summary": "Test", "telegramId": "123"},
+        "comment": {"id": "1", "text": "hi"},
+    }
+
+    response = client.post(
+        "/trackers/comment",
+        json=payload,
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+
+    assert response.status_code == 200
+    assert len(captured) == 2
+    path1, fname1 = captured[0]
+    path2, fname2 = captured[1]
+    assert path1 != path2
+    assert fname1 == fname2 == "same.txt"
+    assert os.path.basename(path1).endswith("_same.txt")
+    assert os.path.basename(path2).endswith("_same.txt")
+    assert not os.path.exists(path1)
+    assert not os.path.exists(path2)

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -11,6 +11,7 @@ from telegram.ext import Application
 from config import Config
 from tracker_client import TrackerAPI
 import os
+import uuid
 
 app = FastAPI()
 
@@ -119,11 +120,12 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
                 file_bytes = await resp.read()
 
             safe_name = os.path.basename(filename)
-            file_path = os.path.join("/tmp", safe_name)
+            unique_name = f"{uuid.uuid4().hex}_{safe_name}"
+            file_path = os.path.join("/tmp", unique_name)
             with open(file_path, "wb") as f:
                 f.write(file_bytes)
 
-            telegram_file = InputFile(file_path)
+            telegram_file = InputFile(file_path, filename=filename)
             if filename.lower().endswith((".jpg", ".png", ".jpeg")):
                 return ("photo", telegram_file, file_path)
             return ("document", telegram_file, file_path)


### PR DESCRIPTION
## Summary
- keep attachment filenames unique when downloading
- store original filename in InputFile
- test sanitizing filenames for attachments
- ensure unique temp files for duplicate filenames

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bb1e0cf38832ba842a3e8349366a3