### PR TITLE
Fix attachment filename handling

### DIFF
--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -423,11 +423,11 @@ def test_download_attachment_sanitizes_filename(monkeypatch):
     mock_session.get.return_value = DummyResp(b"data")
     tracker.get_session = AsyncMock(return_value=mock_session)
 
-    captured_paths = []
+    captured = []
 
     class DummyInputFile:
         def __init__(self, path, filename=None):
-            captured_paths.append(path)
+            captured.append((path, filename))
 
     monkeypatch.setattr(sys.modules["webhook_server"], "InputFile", DummyInputFile)
 
@@ -447,10 +447,12 @@ def test_download_attachment_sanitizes_filename(monkeypatch):
     )
 
     assert response.status_code == 200
-    assert captured_paths
-    basename = os.path.basename(captured_paths[0])
+    assert captured
+    path, fname = captured[0]
+    basename = os.path.basename(path)
     assert basename.endswith("_evil.txt")
-    assert not os.path.exists(captured_paths[0])
+    assert fname == "evil.txt"
+    assert not os.path.exists(path)
 
 
 def test_download_attachment_unique_paths(monkeypatch):

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -125,7 +125,7 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
             with open(file_path, "wb") as f:
                 f.write(file_bytes)
 
-            telegram_file = InputFile(file_path, filename=filename)
+            telegram_file = InputFile(file_path, filename=safe_name)
             if filename.lower().endswith((".jpg", ".png", ".jpeg")):
                 return ("photo", telegram_file, file_path)
             return ("document", telegram_file, file_path)


### PR DESCRIPTION
## Summary
- pass sanitized filename to `InputFile` when downloading attachments
- verify sanitized filename in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bb2bf9940832bafa0a9e1ccf4736b