### PR TITLE
Handle send_document failures safely

### DIFF
--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -536,3 +536,47 @@ def test_large_photo_sent_as_document():
     bot.send_document.assert_called_once()
     bot.send_photo.assert_not_called()
     bot.send_media_group.assert_not_called()
+
+
+def test_send_document_failure_removes_file(monkeypatch):
+    Config.API_TOKEN = "TOKEN"
+    application, tracker, bot = create_mocks()
+
+    tracker.get_attachments_for_comment = AsyncMock(
+        return_value=[{"content_url": "http://files/doc.txt", "filename": "doc.txt"}]
+    )
+
+    mock_session = MagicMock()
+    mock_session.get.return_value = DummyResp(b"data")
+    tracker.get_session = AsyncMock(return_value=mock_session)
+
+    captured = []
+
+    class DummyInputFile:
+        def __init__(self, path, filename=None):
+            captured.append(path)
+
+    monkeypatch.setattr(sys.modules["webhook_server"], "InputFile", DummyInputFile)
+
+    bot.send_document.side_effect = BadRequest("fail")
+
+    app = create_app(application, tracker)
+    client = TestClient(app)
+
+    payload = {
+        "event": "commentCreated",
+        "issue": {"key": "ISSUE-1", "summary": "Test", "telegramId": "123"},
+        "comment": {"id": "1", "text": "hi"},
+    }
+
+    response = client.post(
+        "/trackers/comment",
+        json=payload,
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+
+    assert response.status_code == 200
+    bot.send_document.assert_called_once()
+    assert captured
+    path = captured[0]
+    assert not os.path.exists(path)


### PR DESCRIPTION
## Summary
- ensure temp files are always removed after `send_document`
- test that cleanup occurs even if Telegram rejects the document

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bb6bfdc38832b86ada8275681d1d7