### PR TITLE
Fix message cleanup

### DIFF
--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -333,6 +333,39 @@ def test_receive_webhook_strips_image_links():
     assert "Hello" in sent_text
 
 
+def test_receive_webhook_strips_file_links():
+    Config.API_TOKEN = "TOKEN"
+    application, tracker, bot = create_mocks()
+
+    tracker.get_attachments_for_comment = AsyncMock(return_value=[])
+    mock_session = MagicMock()
+    mock_session.get.return_value = DummyResp()
+    tracker.get_session = AsyncMock(return_value=mock_session)
+
+    app = create_app(application, tracker)
+    client = TestClient(app)
+
+    payload = {
+        "event": "commentCreated",
+        "issue": {"key": "ISSUE-1", "summary": "Test", "telegramId": "123"},
+        "comment": {
+            "id": "1",
+            "text": "Hello :file[doc.doc](/ajax/v2/attachments/1){type=\"application/msword\"}",
+        },
+    }
+
+    response = client.post(
+        "/trackers/comment",
+        json=payload,
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+
+    assert response.status_code == 200
+    sent_text = bot.send_message.call_args.kwargs["text"]
+    assert ":file[" not in sent_text
+    assert "Hello" in sent_text
+
+
 def test_receive_webhook_deduplicates_comment():
     Config.API_TOKEN = "TOKEN"
     application, tracker, bot = create_mocks()

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -33,12 +33,15 @@ def prune_processed_ids() -> None:
 
 # Regex to strip markdown image links like ![alt](url)
 IMAGE_LINK_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+# Regex to strip Tracker file links like :file[name](url){type="..."}
+FILE_LINK_RE = re.compile(r":file\[[^\]]*\]\([^)]*\)(?:\{[^}]*\})?")
 
 def strip_image_links(text: str) -> str:
-    """Remove markdown image links from text."""
+    """Remove markdown image and file links from text."""
     if not text:
         return ""
     cleaned = IMAGE_LINK_RE.sub("", text)
+    cleaned = FILE_LINK_RE.sub("", cleaned)
     cleaned = re.sub(r"\s{2,}", " ", cleaned)
     return cleaned.strip()
 


### PR DESCRIPTION
## Summary
- strip `:file[]()` links from webhook text
- test cleanup of Tracker file links in webhook comments

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68551bbb1c18832b94d4553bbba6caa2