### PR TITLE
Add closing delimiter in comment signatures

### DIFF
--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -374,7 +374,8 @@ async def process_comment(update: Update, context: CallbackContext):
         f"{text}\n\n---\n"
         f"👤 {user.first_name} {user.last_name or ''}\n"
         f"📞 {user_info.get('phone_number', 'неизвестно')}\n"
-        f"🔗 @{user.username or 'без username'}"
+        f"🔗 @{user.username or 'без username'}\n"
+        "---\n"
     )
 
     await tracker.add_comment(issue_key, full_text, attachment_ids)

--- a/tests/test_handlers_issue.py
+++ b/tests/test_handlers_issue.py
@@ -184,3 +184,5 @@ async def test_process_comment_passes_filename(monkeypatch):
     await process_comment(update, context)
 
     assert tracker.upload_file.call_args.args[1] == "doc.txt"
+    sent_text = tracker.add_comment.call_args.args[1]
+    assert sent_text.endswith("\n---\n")

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -36,7 +36,7 @@ IMAGE_LINK_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
 # Regex to strip Tracker file links like :file[name](url){type="..."}
 FILE_LINK_RE = re.compile(r":file\[[^\]]*\]\([^)]*\)(?:\{[^}]*\})?")
 # Regex to remove signature lines appended by the bot
-SIGNATURE_RE = re.compile(r"\n?---\n👤.*", re.DOTALL)
+SIGNATURE_RE = re.compile(r"\n?---\n👤.*?\n---\n?", re.DOTALL)
 
 
 def strip_image_links(text: str) -> str:


### PR DESCRIPTION
## Summary
- append closing `---` delimiter in comment signature
- adjust regex to strip updated signature in webhook server
- check for closing delimiter in test

## Testing
- `pytest tests/test_handlers_issue.py::test_process_comment_passes_filename -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be99f4238832b90ae458d57c45d40