### PR TITLE
Restore full comment text in webhook

### DIFF
--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -366,7 +366,7 @@ def test_receive_webhook_strips_file_links():
     assert "Hello" in sent_text
 
 
-def test_receive_webhook_strips_reply_metadata():
+def test_receive_webhook_preserves_reply_metadata():
     Config.API_TOKEN = "TOKEN"
     application, tracker, bot = create_mocks()
 
@@ -394,8 +394,8 @@ def test_receive_webhook_strips_reply_metadata():
 
     assert response.status_code == 200
     sent_text = bot.send_message.call_args.kwargs["text"]
-    assert "\u0412 \u043e\u0442\u0432\u0435\u0442" not in sent_text  # "В ответ"
-    assert "\ud83d\udc64" not in sent_text  # signature icon
+    assert "\u0412 \u043e\u0442\u0432\u0435\u0442" in sent_text  # "В ответ"
+    assert "\ud83d\udc64" in sent_text  # signature icon
     assert "Reply" in sent_text
 
 

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -64,11 +64,8 @@ def strip_signature(text: str) -> str:
     return SIGNATURE_RE.sub("", text).strip()
 
 def sanitize_comment_text(text: str) -> str:
-    """Apply all text cleanups to a Tracker comment."""
-    text = strip_image_links(text)
-    text = strip_reply_prefix(text)
-    text = strip_signature(text)
-    return text
+    """Apply basic cleanup to a Tracker comment."""
+    return strip_image_links(text)
 
 def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
     """Настраивает маршруты вебхуков"""


### PR DESCRIPTION
## Summary
- keep reply metadata and signatures in webhook comment text
- update tests accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_685be8f14448832bb280ec42145cf67d