### PR TITLE
Handle NBSP in webhook comments

### DIFF
--- a/tests/test_webhook_server.py
+++ b/tests/test_webhook_server.py
@@ -399,6 +399,36 @@ def test_receive_webhook_strips_reply_metadata():
     assert "Reply" in sent_text
 
 
+def test_receive_webhook_converts_nbsp():
+    Config.API_TOKEN = "TOKEN"
+    application, tracker, bot = create_mocks()
+
+    tracker.get_attachments_for_comment = AsyncMock(return_value=[])
+    mock_session = MagicMock()
+    mock_session.get.return_value = DummyResp()
+    tracker.get_session = AsyncMock(return_value=mock_session)
+
+    app = create_app(application, tracker)
+    client = TestClient(app)
+
+    payload = {
+        "event": "commentCreated",
+        "issue": {"key": "ISSUE-1", "summary": "Test", "telegramId": "123"},
+        "comment": {"id": "1", "text": "Hello\xa0World &nbsp;!"},
+    }
+
+    response = client.post(
+        "/trackers/comment",
+        json=payload,
+        headers={"Authorization": "Bearer TOKEN"},
+    )
+
+    assert response.status_code == 200
+    sent_text = bot.send_message.call_args.kwargs["text"]
+    assert "\xa0" not in sent_text
+    assert "&nbsp;" not in sent_text
+
+
 def test_receive_webhook_deduplicates_comment():
     Config.API_TOKEN = "TOKEN"
     application, tracker, bot = create_mocks()

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -72,6 +72,8 @@ def strip_signature(text: str) -> str:
 
 def sanitize_comment_text(text: str) -> str:
     """Apply basic cleanup to a Tracker comment."""
+    # convert HTML non-breaking space entities and unicode NBSP to regular spaces
+    text = text.replace("\xa0", " ").replace("&nbsp;", " ")
     text = strip_image_links(text)
     text = strip_reply_prefix(text)
     text = strip_signature(text)


### PR DESCRIPTION
## Summary
- normalize NBSP characters in sanitize_comment_text
- test NBSP removal in webhook message formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bfc83c280832b968dd57e04e9861a