### PR TITLE
Handle registration via text command

### DIFF
--- a/handlers_common.py
+++ b/handlers_common.py
@@ -127,7 +127,10 @@ async def main_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 def register_handlers(application):
     registration_conv = ConversationHandler(
-        entry_points=[CommandHandler("start", start)],
+        entry_points=[
+            CommandHandler("start", start),
+            MessageHandler(filters.Regex("^Зарегистрироваться$"), start),
+        ],
         states={
             RegistrationStates.waiting_for_contact: [
                 MessageHandler(filters.CONTACT, process_contact),
@@ -145,4 +148,3 @@ def register_handlers(application):
     # --- (ОСТАЛЬНОЕ ОСТАВИТЬ для совместимости) ---
     application.add_handler(MessageHandler(filters.Regex("^🔄 Главное меню$"), main_menu))
     application.add_handler(MessageHandler(filters.Regex("^👤 Моя информация$"), show_user_info))
-    application.add_handler(MessageHandler(filters.Regex("^📝 Зарегистрироваться$"), start))

--- a/tests/test_handlers_common.py
+++ b/tests/test_handlers_common.py
@@ -1,0 +1,42 @@
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+from telegram.ext import ConversationHandler
+
+from handlers_common import start, process_contact
+from states import RegistrationStates
+
+
+@pytest.mark.asyncio
+async def test_registration_flow(monkeypatch):
+    update_start = MagicMock()
+    msg_start = MagicMock()
+    update_start.message = msg_start
+    update_start.effective_user = MagicMock(id=1)
+
+    context = MagicMock()
+    db = MagicMock()
+    db.get_user = AsyncMock(return_value=None)
+    db.register_user = AsyncMock()
+    context.bot_data = {"db": db}
+
+    monkeypatch.setattr("handlers_common.safe_reply_text", AsyncMock())
+    monkeypatch.setattr("handlers_common.safe_delete_message", AsyncMock())
+    monkeypatch.setattr("handlers_common.show_main_reply_menu", AsyncMock())
+
+    state = await start(update_start, context)
+    assert state == RegistrationStates.waiting_for_contact
+
+    update_contact = MagicMock()
+    msg_contact = MagicMock()
+    msg_contact.contact = MagicMock(phone_number="111")
+    update_contact.message = msg_contact
+    update_contact.effective_user = MagicMock(id=1, first_name="A", last_name="B")
+
+    result = await process_contact(update_contact, context)
+    assert result == ConversationHandler.END
+    db.register_user.assert_awaited_once_with(1, "A", "B", "111")


### PR DESCRIPTION
## Summary
- allow users to start registration via the text message `Зарегистрироваться`
- remove redundant handler for registration
- test registration flow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0ea0b724832b860de3ee0aac5b18