### PR TITLE
Fix start registration regex

### DIFF
--- a/handlers_common.py
+++ b/handlers_common.py
@@ -129,7 +129,7 @@ def register_handlers(application):
     registration_conv = ConversationHandler(
         entry_points=[
             CommandHandler("start", start),
-            MessageHandler(filters.Regex("^Зарегистрироваться$"), start),
+            MessageHandler(filters.Regex("^📝 Зарегистрироваться$"), start),
         ],
         states={
             RegistrationStates.waiting_for_contact: [


### PR DESCRIPTION
## Summary
- register registration keyboard handler with correct emoji

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c117145ac832b853013915a7a226f