### PR TITLE
Clear conversation data when listing tasks

### DIFF
--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -66,6 +66,8 @@ async def my_issues(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     Функция работает и для inline-кнопок, и для текстовой команды.
     """
     logging.info("my_issues requested by %s", update.effective_user.id)
+    # Сбрасываем временные данные, если пользователь прервал создание задачи
+    context.user_data.clear()
     telegram_id = update.effective_user.id
     db: Database = context.bot_data["db"]
     if not await db.get_user(telegram_id):

--- a/tests/test_handlers_issue.py
+++ b/tests/test_handlers_issue.py
@@ -214,6 +214,33 @@ async def test_my_issues_unregistered():
 
 
 @pytest.mark.asyncio
+async def test_my_issues_clears_user_data(monkeypatch):
+    update = MagicMock()
+    msg = MagicMock()
+    update.message = msg
+    update.callback_query = None
+    update.effective_user = MagicMock(id=1)
+    msg.reply_text = AsyncMock()
+
+    context = MagicMock()
+    context.user_data = {"tmp": "data"}
+    db = MagicMock()
+    db.get_user = AsyncMock(return_value={})
+    tracker = MagicMock()
+    tracker.get_active_issues_by_telegram_id = AsyncMock(return_value=[])
+    context.bot_data = {"db": db, "tracker": tracker}
+
+    monkeypatch.setattr(
+        sys.modules["handlers_issue"], "safe_delete_message", AsyncMock()
+    )
+
+    await my_issues(update, context)
+
+    assert context.user_data == {}
+    msg.reply_text.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_start_create_issue_unregistered():
     update = MagicMock()
     update.effective_user = MagicMock(id=1)


### PR DESCRIPTION
## Summary
- reset `context.user_data` when a user requests task list
- test that listing tasks clears user data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c196ab334832b8b044547ed8853be