### PR TITLE
Ensure messages deleted in my_issues

### DIFF
--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -102,6 +102,7 @@ async def my_issues(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             await update.callback_query.edit_message_text(NO_ISSUES, reply_markup=markup)
         elif update.message:
             await update.message.reply_text(NO_ISSUES, reply_markup=markup)
+        if update.message:
             await safe_delete_message(update.message)
         return
 
@@ -110,6 +111,7 @@ async def my_issues(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await update.callback_query.edit_message_text(ISSUES_LIST, reply_markup=markup)
     elif update.message:
         await update.message.reply_text(ISSUES_LIST, reply_markup=markup)
+    if update.message:
         await safe_delete_message(update.message)
 
 # ═══════════════════════════ создание задачи (FSM) ════════════════════════════

--- a/tests/test_handlers_issue.py
+++ b/tests/test_handlers_issue.py
@@ -230,14 +230,16 @@ async def test_my_issues_clears_user_data(monkeypatch):
     tracker.get_active_issues_by_telegram_id = AsyncMock(return_value=[])
     context.bot_data = {"db": db, "tracker": tracker}
 
+    delete_mock = AsyncMock()
     monkeypatch.setattr(
-        sys.modules["handlers_issue"], "safe_delete_message", AsyncMock()
+        sys.modules["handlers_issue"], "safe_delete_message", delete_mock
     )
 
     await my_issues(update, context)
 
     assert context.user_data == {}
     msg.reply_text.assert_called_once()
+    delete_mock.assert_called_once_with(msg)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- always delete the user's command message inside `my_issues`
- verify `safe_delete_message` gets called when handling `/my_issues`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c1bc11b38832bbdd2cd8f292a8e17