### PR TITLE
Handle deletion of issue list message

### DIFF
--- a/handlers_common.py
+++ b/handlers_common.py
@@ -39,6 +39,9 @@ async def show_main_reply_menu(update: Update, context: ContextTypes.DEFAULT_TYP
             parse_mode="HTML",
         )
     elif update.message:
+        msg = context.user_data.pop("issues_list_message", None)
+        if msg:
+            await safe_delete_message(msg)
         await update.message.reply_text(
             MAIN_MENU,
             reply_markup=main_reply_keyboard(),
@@ -117,12 +120,18 @@ async def main_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if update.callback_query:
         await update.callback_query.answer()
         await update.callback_query.edit_message_reply_markup(reply_markup=None)
+        msg = context.user_data.pop("issues_list_message", None)
+        if msg:
+            await safe_delete_message(msg)
         await update.callback_query.message.reply_text(
             MAIN_MENU,
             reply_markup=main_reply_keyboard(),
             parse_mode="HTML",
         )
     elif update.message:
+        msg = context.user_data.pop("issues_list_message", None)
+        if msg:
+            await safe_delete_message(msg)
         await update.message.reply_text(
             MAIN_MENU,
             reply_markup=main_reply_keyboard(),

--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -109,8 +109,10 @@ async def my_issues(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if update.callback_query:
         await update.callback_query.answer()
         await update.callback_query.edit_message_text(ISSUES_LIST, reply_markup=markup)
+        context.user_data["issues_list_message"] = update.callback_query.message
     elif update.message:
-        await update.message.reply_text(ISSUES_LIST, reply_markup=markup)
+        sent = await update.message.reply_text(ISSUES_LIST, reply_markup=markup)
+        context.user_data["issues_list_message"] = sent
     if update.message:
         await safe_delete_message(update.message)
 
@@ -370,6 +372,9 @@ async def select_issue_for_comment(update: Update, context: CallbackContext):
     query = update.callback_query
     issue_key = query.data.split("_", 1)[1]
     context.user_data["issue_key"] = issue_key
+    msg = context.user_data.pop("issues_list_message", None)
+    if msg:
+        await safe_delete_message(msg)
     await query.message.reply_text(
         COMMENT_PROMPT,
         reply_markup=InlineKeyboardMarkup(


### PR DESCRIPTION
## Summary
- track the "📂 Ваши задачи:" message in user_data when showing the issue list
- remove the message when navigating to main menu or selecting an issue

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68676463da3c832b9839ee6134b7fbcd