### PR TITLE
Unify placeholder names

### DIFF
--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -369,7 +369,7 @@ async def confirm_issue_creation(update: Update, context: CallbackContext):
     if issue and "key" in issue:
         await db.create_issue(user.id, issue["key"])
         logging.info("issue %s created for %s", issue['key'], user.id)
-        text = ISSUE_CREATED.format(key=issue['key'], title=html.escape(title))
+        text = ISSUE_CREATED.format(issue_key=issue['key'], summary=html.escape(title))
         await safe_reply_text(
             query.message,
             text,

--- a/messages.py
+++ b/messages.py
@@ -24,8 +24,8 @@ FILE_TOO_LARGE = "❌ Размер файла превышает 50МБ."
 ALBUM_FILE_FAILED = "❌ Не удалось загрузить одно из фото. Отправьте альбом снова."
 
 ISSUE_CREATED = (
-    "✅ Задача {key} (https://tracker.yandex.ru/{key}) успешно создана!\n"
-    "<b>Наименование:</b> {title}"
+    "✅ Задача {issue_key} (https://tracker.yandex.ru/{issue_key}) успешно создана!\n"
+    "<b>Наименование:</b> {summary}"
 )
 ISSUE_CREATION_ERROR = "❌ Ошибка при создании задачи. Попробуйте позже."
 
@@ -41,12 +41,12 @@ ISSUES_LIST = "📂 Ваши задачи:"
 TELEGRAM_ERROR = "⚠️ Ошибка связи с Telegram. Попробуйте ещё раз."
 
 WEBHOOK_COMMENT = (
-    "💬 Добавлен комментарий - <a href='https://tracker.yandex.ru/{issue_key}'>{issue_summary}</a>\n\n"
+    "💬 Добавлен комментарий - <a href='https://tracker.yandex.ru/{issue_key}'>{summary}</a>\n\n"
     "<blockquote>{text}</blockquote>\n\n"
     "<b>👤 Автор комментария:</b> {author}"
 )
 WEBHOOK_STATUS = (
-    "🔄 Статус задачи - <a href='https://tracker.yandex.ru/{issue_key}'>{issue_summary}</a> изменен...\n\n"
+    "🔄 Статус задачи - <a href='https://tracker.yandex.ru/{issue_key}'>{summary}</a> изменен...\n\n"
     "<b>📊 Новый статус:</b> {status_name}\n"
     "<b>👤 Кто изменил:</b> {changed_by}"
 )

--- a/webhook_server.py
+++ b/webhook_server.py
@@ -99,7 +99,7 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
         comment_data = data.get("comment", {})
         issue_key = issue.get("key")
         comment_id = comment_data.get("id")
-        issue_summary = issue.get("summary", "Нет темы")
+        summary = issue.get("summary", "Нет темы")
 
         prune_processed_ids()
 
@@ -185,7 +185,7 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
         clean_text = sanitize_comment_text(comment_data.get("text", ""))
         message_text = WEBHOOK_COMMENT.format(
             issue_key=issue_key,
-            issue_summary=issue_summary,
+            summary=summary,
             text=clean_text,
             author=comment_author,
         )
@@ -291,7 +291,7 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
 
         issue = data.get("issue") or {}
         issue_key = issue.get("key")
-        issue_summary = issue.get("summary", "Нет темы")
+        summary = issue.get("summary", "Нет темы")
         telegram_id = issue.get("telegramId")
 
         changed_by = data.get("changedBy") or data.get("updatedBy") or {}
@@ -321,7 +321,7 @@ def setup_webhook_routes(app, application: Application, tracker: TrackerAPI):
 
         message_text = WEBHOOK_STATUS.format(
             issue_key=issue_key,
-            issue_summary=issue_summary,
+            summary=summary,
             status_name=status_name,
             changed_by=changed_by,
         )


### PR DESCRIPTION
## Summary
- standardize placeholders for messages
- update handlers and webhook server to use unified names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68676bd0f928832ba4c553d2bf72f615