### PR TITLE
Fix cancel create task flow

### DIFF
--- a/handlers_common.py
+++ b/handlers_common.py
@@ -200,9 +200,9 @@ def register_handlers(application):
     application.add_handler(registration_conv)
 
     # --- INLINE-КНОПКИ ---
-    application.add_handler(CallbackQueryHandler(main_menu, pattern="^main_menu$"))
-    application.add_handler(CallbackQueryHandler(show_user_info, pattern="^user_info$"))
+    application.add_handler(CallbackQueryHandler(main_menu, pattern="^main_menu$"), group=1)
+    application.add_handler(CallbackQueryHandler(show_user_info, pattern="^user_info$"), group=1)
 
     # --- (ОСТАЛЬНОЕ ОСТАВИТЬ для совместимости) ---
-    application.add_handler(MessageHandler(filters.Regex("^🔄 Главное меню$"), main_menu))
-    application.add_handler(MessageHandler(filters.Regex("^👤 Моя информация$"), show_user_info))
+    application.add_handler(MessageHandler(filters.Regex("^🔄 Главное меню$"), main_menu), group=1)
+    application.add_handler(MessageHandler(filters.Regex("^👤 Моя информация$"), show_user_info), group=1)

--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -56,7 +56,7 @@ from messages import (
     NOT_REGISTERED,
     REQUEST_PENDING,
 )
-from handlers_common import check_rate_limit
+from handlers_common import check_rate_limit, show_main_reply_menu
 
 # ──────────────────────────── буфер медиа‑альбомов ─────────────────────────────
 
@@ -531,6 +531,7 @@ def register_handlers(app):
     async def do_nothing(update, context):
         if update.callback_query:
             await update.callback_query.answer()
+        await show_main_reply_menu(update, context)
         return ConversationHandler.END
 
     conv = ConversationHandler(


### PR DESCRIPTION
## Summary
- show main menu after canceling issue flow
- delay main menu handlers to let FSM end first

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867a290f458832b9c1f7ce6d5c4b67b