### PR TITLE
Fix missing message error on Telegram callbacks

### DIFF
--- a/handlers_common.py
+++ b/handlers_common.py
@@ -10,6 +10,7 @@ from send_monitor import (
     safe_send_message,
     safe_reply_text,
     safe_delete_message,
+    safe_edit_message_reply_markup,
 )
 from telegram.ext import (
     CommandHandler, MessageHandler, CallbackQueryHandler, ConversationHandler, filters
@@ -160,7 +161,9 @@ async def main_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
             return
     if update.callback_query:
         await update.callback_query.answer()
-        await update.callback_query.edit_message_reply_markup(reply_markup=None)
+        await safe_edit_message_reply_markup(
+            update.callback_query, reply_markup=None
+        )
         msg = context.user_data.pop("issues_list_message", None)
         if msg:
             await safe_delete_message(msg)

--- a/send_monitor.py
+++ b/send_monitor.py
@@ -3,6 +3,7 @@
 import logging
 import time
 from telegram.error import BadRequest
+import asyncio
 
 SEND_LOG = []
 
@@ -43,5 +44,25 @@ async def safe_delete_message(message):
             logging.exception("[safe_delete_message] %s", exc)
     except Exception as exc:
         logging.exception("[safe_delete_message] %s", exc)
+
+async def safe_edit_message_reply_markup(obj, *args, **kwargs):
+    """Edit message reply markup and ignore missing-message errors."""
+    try:
+        result = obj.edit_message_reply_markup(*args, **kwargs)
+        if asyncio.iscoroutine(result):
+            await result
+    except BadRequest as exc:
+        if str(exc) == "Message to edit not found":
+            logging.warning(
+                "[safe_edit_message_reply_markup] message already deleted"
+            )
+        else:
+            logging.exception(
+                "[safe_edit_message_reply_markup] %s", exc
+            )
+    except Exception as exc:
+        logging.exception(
+            "[safe_edit_message_reply_markup] %s", exc
+        )
 
 # Дополнительно можешь сделать так для send_photo, edit_message и т.д., если надо отслеживать и их.


### PR DESCRIPTION
## Summary
- handle missing message errors for `edit_message_reply_markup`
- use the safe edit function in the main menu handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867abcf7f44832b8b92c54b5a0a0208