### PR TITLE
Handle done status

### DIFF
--- a/tests/test_tracker_client.py
+++ b/tests/test_tracker_client.py
@@ -101,6 +101,7 @@ async def test_get_active_issues_filters_statuses():
         {'key': 'ISSUE-1', 'status': {'key': 'open'}},
         {'key': 'ISSUE-2', 'status': {'key': 'closed'}},
         {'key': 'ISSUE-3', 'status': {'key': 'canceled'}},
+        {'key': 'ISSUE-4', 'status': {'key': 'done'}},
     ])
     api.get_session = AsyncMock(return_value=mock_session)
 

--- a/tracker_client.py
+++ b/tracker_client.py
@@ -168,11 +168,12 @@ class TrackerAPI:
                 raise Exception(f"Search issues failed: {resp.status} {text}")
             issues = await resp.json()
 
-        # Фильтруем закрытые и отменённые задачи вручную
+        # Фильтруем закрытые, отменённые и завершённые задачи вручную
         filtered = [
             issue
             for issue in issues
-            if issue.get("status", {}).get("key") not in {"closed", "canceled"}
+            if issue.get("status", {}).get("key") not in {"closed", "canceled", "done"}
+            and issue.get("status", {}).get("name") not in {"Завершено", "Отменено"}
         ]
         return filtered
 


### PR DESCRIPTION
## Summary
- ignore issues in `done` status when listing tasks
- test filtering `done` status

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867b37e4e8c832b891cf89f1640cb60