### PR TITLE
Improve Telegram request performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ The bot is configured via environment variables. You can place them in a `.env` 
 | Variable | Description |
 |----------|-------------|
 | `BOT_TOKEN` | Telegram bot token |
+| `TELEGRAM_POOL_SIZE` | Number of HTTP connections for Telegram API |
+| `TELEGRAM_KEEPALIVE` | Keep-alive pool size for Telegram requests |
+| `TELEGRAM_READ_TIMEOUT` | Read timeout for Telegram requests |
+| `TELEGRAM_CONNECT_TIMEOUT` | Connect timeout for Telegram requests |
+| `TELEGRAM_HTTP2` | Enable HTTP/2 for Telegram API (`1`/`0`) |
 | `TRACKER_TOKEN` | Yandex Tracker API token |
 | `TRACKER_ORG_ID` | Tracker organization ID |
 | `TRACKER_QUEUE` | Default Tracker queue |

--- a/config.py
+++ b/config.py
@@ -6,6 +6,11 @@ load_dotenv(override=True)
 class Config:
     # Telegram
     BOT_TOKEN = os.getenv('BOT_TOKEN')
+    TELEGRAM_POOL_SIZE = int(os.getenv('TELEGRAM_POOL_SIZE', 40))
+    TELEGRAM_KEEPALIVE = int(os.getenv('TELEGRAM_KEEPALIVE', TELEGRAM_POOL_SIZE // 2))
+    TELEGRAM_READ_TIMEOUT = float(os.getenv('TELEGRAM_READ_TIMEOUT', 60))
+    TELEGRAM_CONNECT_TIMEOUT = float(os.getenv('TELEGRAM_CONNECT_TIMEOUT', 30))
+    TELEGRAM_HTTP2 = os.getenv('TELEGRAM_HTTP2', '1') not in ('0', 'false', 'False')
     
     # Yandex Tracker
     TRACKER_TOKEN = os.getenv('TRACKER_TOKEN')

--- a/main.py
+++ b/main.py
@@ -77,12 +77,14 @@ async def main() -> None:
         .token(BOT_TOKEN)
         .request(
             HTTPXRequest(
-                connection_pool_size=20,
-                read_timeout=60,
-                connect_timeout=30,
+                connection_pool_size=Config.TELEGRAM_POOL_SIZE,
+                read_timeout=Config.TELEGRAM_READ_TIMEOUT,
+                connect_timeout=Config.TELEGRAM_CONNECT_TIMEOUT,
+                http_version="2" if Config.TELEGRAM_HTTP2 else "1.1",
                 httpx_kwargs={
                     "limits": Limits(
-                        max_connections=20, max_keepalive_connections=10
+                        max_connections=Config.TELEGRAM_POOL_SIZE,
+                        max_keepalive_connections=Config.TELEGRAM_KEEPALIVE,
                     )
                 },
             )


### PR DESCRIPTION
## Summary
- tune `HTTPXRequest` connection pool and HTTP2 usage
- expose new Telegram connection settings in `Config`
- document environment variables for optimizing Telegram requests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687760d4c050832b988910b652308ed3