### PR TITLE
Add tracker pool limit config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The bot is configured via environment variables. You can place them in a `.env` 
 | `TRACKER_TOKEN` | Yandex Tracker API token |
 | `TRACKER_ORG_ID` | Tracker organization ID |
 | `TRACKER_QUEUE` | Default Tracker queue |
+| `TRACKER_POOL_LIMIT` | HTTP connection limit for Tracker API |
 | `API_TOKEN` | Token used to authorize incoming webhooks |
 | `DB_USER` | PostgreSQL user name |
 | `DB_PASSWORD` | PostgreSQL user password |

--- a/config.py
+++ b/config.py
@@ -16,6 +16,7 @@ class Config:
     TRACKER_TOKEN = os.getenv('TRACKER_TOKEN')
     TRACKER_ORG_ID = os.getenv('TRACKER_ORG_ID')
     TRACKER_QUEUE = os.getenv('TRACKER_QUEUE')  # Добавлено
+    TRACKER_POOL_LIMIT = int(os.getenv('TRACKER_POOL_LIMIT', 20))
 
     API_TOKEN = os.getenv('API_TOKEN')  # Добавлено
 

--- a/tracker_client.py
+++ b/tracker_client.py
@@ -3,6 +3,7 @@ import os
 import asyncio
 import aiohttp
 import mimetypes
+from config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +24,9 @@ class TrackerAPI:
         if session is None or session.closed:
             timeout = aiohttp.ClientTimeout(total=60)
             if self._connector is None or self._connector.closed:
-                self._connector = aiohttp.TCPConnector(limit=20)
+                self._connector = aiohttp.TCPConnector(
+                    limit=Config.TRACKER_POOL_LIMIT
+                )
             session = aiohttp.ClientSession(timeout=timeout, connector=self._connector)
             self._sessions[loop] = session
         return session


### PR DESCRIPTION
## Summary
- add `TRACKER_POOL_LIMIT` setting and use it in `TrackerAPI`
- document the new variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877807fffb0832b99877fd135d290af