### PR TITLE
Add n8n webhook forwarding

### DIFF
--- a/n8n_client.py
+++ b/n8n_client.py
@@ -2,6 +2,10 @@ import aiohttp
 import os
 
 N8N_BASE_URL = os.getenv("N8N_BASE_URL")  # например, http://localhost:5678
+N8N_MESSAGE_WEBHOOK_URL = os.getenv(
+    "N8N_MESSAGE_WEBHOOK_URL",
+    "http://n8n.mxmit.ru:5678/webhook-test/15ce4d64-adee-4522-8591-8463573d0bc6/webhook",
+)
 
 async def n8n_create_issue(title, description, telegram_id, attachments=None):
     url = f"{N8N_BASE_URL}/n8n/create_issue"
@@ -16,5 +20,21 @@ async def n8n_create_issue(title, description, telegram_id, attachments=None):
             if resp.status != 200:
                 raise Exception(await resp.text())
             return await resp.json()
+
+
+async def n8n_forward_message(token: str, message: str):
+    """Send a user message to the configured n8n webhook."""
+    if not N8N_MESSAGE_WEBHOOK_URL:
+        raise RuntimeError("N8N_MESSAGE_WEBHOOK_URL not configured")
+
+    payload = {"token": token, "message": message}
+    async with aiohttp.ClientSession() as session:
+        async with session.post(N8N_MESSAGE_WEBHOOK_URL, json=payload) as resp:
+            if resp.status != 200:
+                raise Exception(await resp.text())
+            try:
+                return await resp.json()
+            except Exception:
+                return await resp.text()
 
 # Аналогично реализуем n8n_add_comment, n8n_get_issues, n8n_upload_file и т.д.

--- a/tests/test_handlers_common.py
+++ b/tests/test_handlers_common.py
@@ -62,3 +62,24 @@ async def test_start_registration_button(monkeypatch):
     result = await start(update, context)
 
     assert result == RegistrationStates.waiting_for_contact
+
+
+@pytest.mark.asyncio
+async def test_forward_message_to_n8n(monkeypatch):
+    update = MagicMock()
+    message = MagicMock()
+    message.text = "hello"
+    update.message = message
+    update.effective_user = MagicMock(id=1)
+
+    context = MagicMock()
+    context.bot = MagicMock(token="TOKEN")
+
+    forward_mock = AsyncMock()
+    monkeypatch.setattr("handlers_common.n8n_forward_message", forward_mock)
+
+    from handlers_common import forward_message_to_n8n
+
+    await forward_message_to_n8n(update, context)
+
+    forward_mock.assert_awaited_once_with("TOKEN", "hello")


### PR DESCRIPTION
## Summary
- add n8n message webhook URL and forwarding helper
- forward plain text messages to n8n
- test the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688086e68de4832bb510285108d07cfb