### PR TITLE
Fix telegram polling when webhook is active

### DIFF
--- a/main.py
+++ b/main.py
@@ -128,6 +128,8 @@ async def main() -> None:
     try:
         await application.initialize()
         await application.start()
+        # Remove any previously set webhook so polling works
+        await application.bot.delete_webhook(drop_pending_updates=True)
         await application.updater.start_polling()
         logging.info("✅ Бот запущен и ожидает события")
 


### PR DESCRIPTION
## Summary
- fix conflict when starting polling by deleting existing webhook first

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68808f5937a4832ba487a74be4c2a1da