### PR TITLE
Adjust n8n forward payload

### DIFF
--- a/handlers_common.py
+++ b/handlers_common.py
@@ -194,9 +194,12 @@ async def forward_message_to_n8n(update: Update, context: ContextTypes.DEFAULT_T
     """Forward plain text messages to the n8n webhook."""
     if not update.message or not update.message.text:
         return
-    token = context.bot.token
     try:
-        await n8n_forward_message(token, update.message.text)
+        await n8n_forward_message(
+            update.message.text,
+            update.effective_user.id,
+            update.message.chat_id,
+        )
     except Exception as exc:
         logging.error("Failed to forward message to n8n: %s", exc)
 

--- a/n8n_client.py
+++ b/n8n_client.py
@@ -22,12 +22,12 @@ async def n8n_create_issue(title, description, telegram_id, attachments=None):
             return await resp.json()
 
 
-async def n8n_forward_message(token: str, message: str):
+async def n8n_forward_message(message: str, user_id: int, chat_id: int):
     """Send a user message to the configured n8n webhook."""
     if not N8N_MESSAGE_WEBHOOK_URL:
         raise RuntimeError("N8N_MESSAGE_WEBHOOK_URL not configured")
 
-    payload = {"token": token, "message": message}
+    payload = {"message": message, "userid": user_id, "chatid": chat_id}
     async with aiohttp.ClientSession() as session:
         async with session.post(N8N_MESSAGE_WEBHOOK_URL, json=payload) as resp:
             if resp.status != 200:

--- a/tests/test_handlers_common.py
+++ b/tests/test_handlers_common.py
@@ -69,6 +69,7 @@ async def test_forward_message_to_n8n(monkeypatch):
     update = MagicMock()
     message = MagicMock()
     message.text = "hello"
+    message.chat_id = 42
     update.message = message
     update.effective_user = MagicMock(id=1)
 
@@ -82,4 +83,4 @@ async def test_forward_message_to_n8n(monkeypatch):
 
     await forward_message_to_n8n(update, context)
 
-    forward_mock.assert_awaited_once_with("TOKEN", "hello")
+    forward_mock.assert_awaited_once_with("hello", 1, 42)


### PR DESCRIPTION
## Summary
- send user and chat info when forwarding messages to the n8n webhook
- update forwarding handler
- adjust tests for new payload

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a07e1254832bb9c05fa07b0efd49