### PR TITLE
Add chat session management for n8n forwarding

### DIFF
--- a/n8n_client.py
+++ b/n8n_client.py
@@ -22,12 +22,17 @@ async def n8n_create_issue(title, description, telegram_id, attachments=None):
             return await resp.json()
 
 
-async def n8n_forward_message(message: str, user_id: int, chat_id: int):
+async def n8n_forward_message(message: str, user_id: int, chat_id: int, session_id: str):
     """Send a user message to the configured n8n webhook."""
     if not N8N_MESSAGE_WEBHOOK_URL:
         raise RuntimeError("N8N_MESSAGE_WEBHOOK_URL not configured")
 
-    payload = {"message": message, "userid": user_id, "chatid": chat_id}
+    payload = {
+        "message": message,
+        "userid": user_id,
+        "chatid": chat_id,
+        "session_id": session_id,
+    }
     async with aiohttp.ClientSession() as session:
         async with session.post(N8N_MESSAGE_WEBHOOK_URL, json=payload) as resp:
             if resp.status != 200:

--- a/tests/test_handlers_common.py
+++ b/tests/test_handlers_common.py
@@ -75,6 +75,7 @@ async def test_forward_message_to_n8n(monkeypatch):
 
     context = MagicMock()
     context.bot = MagicMock(token="TOKEN")
+    context.chat_data = {}
 
     forward_mock = AsyncMock()
     monkeypatch.setattr("handlers_common.n8n_forward_message", forward_mock)
@@ -83,4 +84,10 @@ async def test_forward_message_to_n8n(monkeypatch):
 
     await forward_message_to_n8n(update, context)
 
-    forward_mock.assert_awaited_once_with("hello", 1, 42)
+    forward_mock.assert_awaited_once()
+    args, _ = forward_mock.call_args
+    assert args[0] == "hello"
+    assert args[1] == 1
+    assert args[2] == 42
+    session_id = args[3]
+    assert context.chat_data["session_id"] == session_id


### PR DESCRIPTION
## Summary
- add optional chat session tracking in `handlers_common`
- forward Telegram messages to n8n with a `session_id`
- adjust tests for the new parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e1b89a08832bb216fbd83815ae3f