### PR TITLE
Fix create issue button after album upload

### DIFF
--- a/handlers_issue.py
+++ b/handlers_issue.py
@@ -320,6 +320,7 @@ async def handle_photo_or_album(update: Update, context: CallbackContext):  # no
         # запускаем отложенную обработку альбома только при первом фото
         if len(_album_buffer[gid]) == 1:
             asyncio.create_task(_process_album_later(gid, context))
+        return IssueStates.waiting_for_attachment
     else:
         # одиночное фото/документ
         return await handle_attachment(update, context)


### PR DESCRIPTION
## Summary
- keep conversation active when processing album uploads

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b193413b8832b86c01f1fcde9f137